### PR TITLE
openssl: keep timestamps of installed headers and libs

### DIFF
--- a/openssl/01-makefile-install_keeps_timestamps.patch
+++ b/openssl/01-makefile-install_keeps_timestamps.patch
@@ -1,0 +1,106 @@
+diff -Nuar openssl-1.1.1a-orig/Configurations/unix-Makefile.tmpl openssl-1.1.1a/Configurations/unix-Makefile.tmpl
+--- openssl-1.1.1a-orig/Configurations/unix-Makefile.tmpl	2018-11-20 14:35:37.000000000 +0100
++++ openssl-1.1.1a/Configurations/unix-Makefile.tmpl	2021-09-15 11:14:50.324333125 +0200
+@@ -497,21 +497,21 @@
+ 	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(INSTALLTOP)/include/openssl
+ 	@ : {- output_off() unless grep { $_ eq "OPENSSL_USE_APPLINK" } (@{$target{defines}}, @{$config{defines}}); "" -}
+ 	@$(ECHO) "install $(SRCDIR)/ms/applink.c -> $(DESTDIR)$(INSTALLTOP)/include/openssl/applink.c"
+-	@cp $(SRCDIR)/ms/applink.c $(DESTDIR)$(INSTALLTOP)/include/openssl/applink.c
++	@cp -a $(SRCDIR)/ms/applink.c $(DESTDIR)$(INSTALLTOP)/include/openssl/applink.c
+ 	@chmod 644 $(DESTDIR)$(INSTALLTOP)/include/openssl/applink.c
+ 	@ : {- output_on() unless grep { $_ eq "OPENSSL_USE_APPLINK" } (@{$target{defines}}, @{$config{defines}}); "" -}
+ 	@set -e; for i in $(SRCDIR)/include/openssl/*.h \
+ 			  $(BLDDIR)/include/openssl/*.h; do \
+ 		fn=`basename $$i`; \
+ 		$(ECHO) "install $$i -> $(DESTDIR)$(INSTALLTOP)/include/openssl/$$fn"; \
+-		cp $$i $(DESTDIR)$(INSTALLTOP)/include/openssl/$$fn; \
++		cp -a $$i $(DESTDIR)$(INSTALLTOP)/include/openssl/$$fn; \
+ 		chmod 644 $(DESTDIR)$(INSTALLTOP)/include/openssl/$$fn; \
+ 	done
+ 	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(libdir)
+ 	@set -e; for l in $(INSTALL_LIBS); do \
+ 		fn=`basename $$l`; \
+ 		$(ECHO) "install $$l -> $(DESTDIR)$(libdir)/$$fn"; \
+-		cp $$l $(DESTDIR)$(libdir)/$$fn.new; \
++		cp -a $$l $(DESTDIR)$(libdir)/$$fn.new; \
+ 		$(RANLIB) $(DESTDIR)$(libdir)/$$fn.new; \
+ 		chmod 644 $(DESTDIR)$(libdir)/$$fn.new; \
+ 		mv -f $(DESTDIR)$(libdir)/$$fn.new \
+@@ -530,7 +530,7 @@
+ 		fi; \
+ 		: {- output_off() unless windowsdll() or sharedaix(); output_on() if windowsdll(); "" -}; \
+ 		$(ECHO) "install $$s2 -> $(DESTDIR)$(libdir)/$$fn2"; \
+-		cp $$s2 $(DESTDIR)$(libdir)/$$fn2.new; \
++		cp -a $$s2 $(DESTDIR)$(libdir)/$$fn2.new; \
+ 		chmod 755 $(DESTDIR)$(libdir)/$$fn2.new; \
+ 		mv -f $(DESTDIR)$(libdir)/$$fn2.new \
+ 		      $(DESTDIR)$(libdir)/$$fn2; \
+@@ -539,7 +539,7 @@
+ 		$(ECHO) "install $$s1 -> $$a"; \
+ 		if [ -f $$a ]; then ( trap "rm -rf /tmp/ar.$$$$" INT 0; \
+ 			mkdir /tmp/ar.$$$$; ( cd /tmp/ar.$$$$; \
+-			cp -f $$a $$a.new; \
++			cp -a -f $$a $$a.new; \
+ 			for so in `$(AR) t $$a`; do \
+ 				$(AR) x $$a $$so; \
+ 				chmod u+w $$so; \
+@@ -554,13 +554,13 @@
+ 	@ : {- output_on() if $disabled{shared}; "" -}
+ 	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(libdir)/pkgconfig
+ 	@$(ECHO) "install libcrypto.pc -> $(DESTDIR)$(libdir)/pkgconfig/libcrypto.pc"
+-	@cp libcrypto.pc $(DESTDIR)$(libdir)/pkgconfig
++	@cp -a libcrypto.pc $(DESTDIR)$(libdir)/pkgconfig
+ 	@chmod 644 $(DESTDIR)$(libdir)/pkgconfig/libcrypto.pc
+ 	@$(ECHO) "install libssl.pc -> $(DESTDIR)$(libdir)/pkgconfig/libssl.pc"
+-	@cp libssl.pc $(DESTDIR)$(libdir)/pkgconfig
++	@cp -a libssl.pc $(DESTDIR)$(libdir)/pkgconfig
+ 	@chmod 644 $(DESTDIR)$(libdir)/pkgconfig/libssl.pc
+ 	@$(ECHO) "install openssl.pc -> $(DESTDIR)$(libdir)/pkgconfig/openssl.pc"
+-	@cp openssl.pc $(DESTDIR)$(libdir)/pkgconfig
++	@cp -a openssl.pc $(DESTDIR)$(libdir)/pkgconfig
+ 	@chmod 644 $(DESTDIR)$(libdir)/pkgconfig/openssl.pc
+ 
+ uninstall_dev: uninstall_runtime_libs
+@@ -615,7 +615,7 @@
+ 		if [ "$$e" = "dummy" ]; then continue; fi; \
+ 		fn=`basename $$e`; \
+ 		$(ECHO) "install $$e -> $(DESTDIR)$(ENGINESDIR)/$$fn"; \
+-		cp $$e $(DESTDIR)$(ENGINESDIR)/$$fn.new; \
++		cp -a $$e $(DESTDIR)$(ENGINESDIR)/$$fn.new; \
+ 		chmod 755 $(DESTDIR)$(ENGINESDIR)/$$fn.new; \
+ 		mv -f $(DESTDIR)$(ENGINESDIR)/$$fn.new \
+ 		      $(DESTDIR)$(ENGINESDIR)/$$fn; \
+@@ -649,13 +649,13 @@
+ 		fn=`basename $$s`; \
+ 		: {- output_off() unless windowsdll(); "" -}; \
+ 		$(ECHO) "install $$s -> $(DESTDIR)$(INSTALLTOP)/bin/$$fn"; \
+-		cp $$s $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new; \
++		cp -a $$s $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new; \
+ 		chmod 644 $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new; \
+ 		mv -f $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new \
+ 		      $(DESTDIR)$(INSTALLTOP)/bin/$$fn; \
+ 		: {- output_on() unless windowsdll(); "" -}{- output_off() if windowsdll(); "" -}; \
+ 		$(ECHO) "install $$s -> $(DESTDIR)$(libdir)/$$fn"; \
+-		cp $$s $(DESTDIR)$(libdir)/$$fn.new; \
++		cp -a $$s $(DESTDIR)$(libdir)/$$fn.new; \
+ 		chmod 755 $(DESTDIR)$(libdir)/$$fn.new; \
+ 		mv -f $(DESTDIR)$(libdir)/$$fn.new \
+ 		      $(DESTDIR)$(libdir)/$$fn; \
+@@ -670,7 +670,7 @@
+ 		if [ "$$x" = "dummy" ]; then continue; fi; \
+ 		fn=`basename $$x`; \
+ 		$(ECHO) "install $$x -> $(DESTDIR)$(INSTALLTOP)/bin/$$fn"; \
+-		cp $$x $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new; \
++		cp -a $$x $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new; \
+ 		chmod 755 $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new; \
+ 		mv -f $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new \
+ 		      $(DESTDIR)$(INSTALLTOP)/bin/$$fn; \
+@@ -679,7 +679,7 @@
+ 		if [ "$$x" = "dummy" ]; then continue; fi; \
+ 		fn=`basename $$x`; \
+ 		$(ECHO) "install $$x -> $(DESTDIR)$(INSTALLTOP)/bin/$$fn"; \
+-		cp $$x $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new; \
++		cp -a $$x $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new; \
+ 		chmod 755 $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new; \
+ 		mv -f $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new \
+ 		      $(DESTDIR)$(INSTALLTOP)/bin/$$fn; \

--- a/openssl/build.sh
+++ b/openssl/build.sh
@@ -9,13 +9,25 @@ PREFIX_OPENSSL="${TOPDIR}/phoenix-rtos-ports/openssl"
 PREFIX_OPENSSL_BUILD="${PREFIX_BUILD}/openssl"
 PREFIX_OPENSSL_SRC="${PREFIX_OPENSSL_BUILD}/${OPENSSL}"
 PREFIX_OPENSSL_INSTALL="$PREFIX_OPENSSL_BUILD/install"
+PREFIX_OPENSSL_MARKERS="$PREFIX_OPENSSL_BUILD/markers/"
 
 #
 # Download and unpack
 #
-mkdir -p "$PREFIX_OPENSSL_BUILD" "$PREFIX_OPENSSL_INSTALL"
+mkdir -p "$PREFIX_OPENSSL_BUILD" "$PREFIX_OPENSSL_INSTALL" "$PREFIX_OPENSSL_MARKERS"
 [ -f "$PREFIX_OPENSSL/${OPENSSL}.tar.gz" ] || wget https://www.openssl.org/source/${OPENSSL}.tar.gz -P "$PREFIX_OPENSSL" --no-check-certificate
 [ -d "$PREFIX_OPENSSL_SRC" ] || tar zxf "$PREFIX_OPENSSL/${OPENSSL}.tar.gz" -C "$PREFIX_OPENSSL_BUILD"
+
+#
+# Apply patches
+#
+for patchfile in "$PREFIX_OPENSSL"/*.patch; do
+	if [ ! -f "$PREFIX_OPENSSL_MARKERS/$(basename "$patchfile").applied" ]; then
+		echo "applying patch: $patchfile"
+		patch -d "$PREFIX_OPENSSL_SRC" -p1 < "$patchfile"
+		touch "$PREFIX_OPENSSL_MARKERS/$(basename "$patchfile").applied"
+	fi
+done
 
 #
 # Configure


### PR DESCRIPTION
## Description

With incremental build the installed openssl library and headers is
installed using "cp" which results in modified timestamp and rebuild of
all things needing openssl. This fix changes the install method to
"cp -a".


## Motivation and Context
Fixes phoenix-rtos/phoenix-rtos-project#185

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
