### PR TITLE
openssl: ia32-generic: disable sse2 instruction set

### DIFF
--- a/openssl/30-phoenix.conf
+++ b/openssl/30-phoenix.conf
@@ -19,6 +19,7 @@ my %targets = (
 		arflags          => "-r",
 	},
 
+	# sse2 instruction set is not supported on Phoenix-RTOS
 	"phoenix-ia32-generic" => {
 		inherit_from     => [ "phoenix", asm("x86_elf_asm") ],
 		cc               => "i386-pc-phoenix-gcc",
@@ -26,6 +27,7 @@ my %targets = (
 		ranlib           => "i386-pc-phoenix-gcc-ranlib",
 		cflags           => "-Os -march=i586 -mtune=generic -Wall -Wstrict-prototypes -g -fomit-frame-pointer -fdata-sections -ffunction-sections",
 		arflags          => "-r",
+		disable          => add("sse2"),
 	},
 
 	"phoenix-riscv64-spike" => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

- openssl: ia32-generic: disable sse2 instruction set

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
JIRA: PD-263

Using some ca-certificates (for example `Baltimore_CyberTrust_Root.crt`) by `openssl` causes executing `sse2` instructions that are not supported on Phoenix-RTOS (ia32-generic). As @Maxez said it's not possible to disable it in the processor, so the `no-sse2` option in `openssl` has to be set. It's required for working azure iot sdk (upcoming port).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
