### PR TITLE
Ziemleszcz/select blocking workaround

### DIFF
--- a/busybox/18-telnetd-select-blocking-workaround.patch
+++ b/busybox/18-telnetd-select-blocking-workaround.patch
@@ -1,0 +1,46 @@
+diff -ruN a/networking/telnetd.c b/networking/telnetd.c
+--- a/networking/telnetd.c	2022-07-14 13:42:23.083820837 +0200
++++ b/networking/telnetd.c	2022-07-18 13:31:44.071832653 +0200
+@@ -649,6 +649,8 @@
+ #define IS_INETD (opt & OPT_INETD)
+ 	int master_fd = master_fd; /* for compiler */
+ 	int sec_linger = sec_linger;
++	int sec_waited = 0;
++	struct timeval tv = { .tv_sec = 1 };
+ 	char *opt_bindaddr = NULL;
+ 	char *opt_portnbr;
+ #else
+@@ -768,22 +770,19 @@
+ 			G.maxfd = master_fd;
+ 	}
+ 
+-	{
+-		struct timeval *tv_ptr = NULL;
++	count = select(G.maxfd + 1, &rdfdset, &wrfdset, NULL, &tv);
+ #if ENABLE_FEATURE_TELNETD_INETD_WAIT
+-		struct timeval tv;
+-		if ((opt & OPT_WAIT) && !G.sessions) {
+-			tv.tv_sec = sec_linger;
+-			tv.tv_usec = 0;
+-			tv_ptr = &tv;
+-		}
+-#endif
+-		count = select(G.maxfd + 1, &rdfdset, &wrfdset, NULL, tv_ptr);
++	if ((opt & OPT_WAIT) && !G.sessions) {
++		if (count == 0)
++			++sec_waited;
++		else
++			sec_waited = 0;
++		if (sec_waited > sec_linger) /* "telnetd -w SEC" timed out */
++			return 0;
+ 	}
+-	if (count == 0) /* "telnetd -w SEC" timed out */
+-		return 0;
+-	if (count < 0)
+-		goto again; /* EINTR or ENOMEM */
++#endif
++	if (count <= 0)
++		goto again; /* EINTR or ENOMEM or timeout */
+ 
+ #if ENABLE_FEATURE_TELNETD_STANDALONE
+ 	/* Check for and accept new sessions */

--- a/dropbear/patch/0002-select_blocking_workaround.patch
+++ b/dropbear/patch/0002-select_blocking_workaround.patch
@@ -1,0 +1,22 @@
+diff -ruN a/svr-main.c b/svr-main.c
+--- a/svr-main.c	2022-02-25 13:33:15.212265510 +0100
++++ b/svr-main.c	2022-07-14 13:36:47.200473962 +0200
+@@ -113,6 +113,7 @@
+ #if NON_INETD_MODE
+ static void main_noinetd() {
+ 	fd_set fds;
++	struct timeval timeout;
+ 	unsigned int i, j;
+ 	int val;
+ 	int maxsock = -1;
+@@ -193,7 +194,9 @@
+ 			}
+ 		}
+ 
+-		val = select(maxsock+1, &fds, NULL, NULL, NULL);
++		timeout.tv_sec = 1;
++		timeout.tv_usec = 0;
++		val = select(maxsock+1, &fds, NULL, NULL, &timeout);
+ 
+ 		if (ses.exitflag) {
+ 			unlink(svr_opts.pidfile);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Don't block forever in select().

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently select() is not interrupted. Running select() on 1 second timeout allows breaking program.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imx6ull).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
