### PR TITLE
Make it possible to compile part of the ports on macos

### DIFF
--- a/azure_sdk/build.sh
+++ b/azure_sdk/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Shell script for building Phoenix-RTOS ports
 #

--- a/busybox/build.sh
+++ b/busybox/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/curl/build.sh
+++ b/curl/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/dropbear/build.sh
+++ b/dropbear/build.sh
@@ -46,7 +46,7 @@ if [ ! -f "$PREFIX_DROPBEAR_BUILD/config.h" ]; then
 
 	( cd "${PREFIX_DROPBEAR_BUILD}" && "${PREFIX_DROPBEAR_SRC}/configure" CPPFLAGS="${CFLAGS} ${DROPBEAR_CFLAGS}" CFLAGS="${CFLAGS} ${DROPBEAR_CFLAGS}" \
 		LDFLAGS="${CFLAGS} ${LDFLAGS} ${DROPBEAR_LDFLAGS}" ARFLAGS="-r" \
-		--host="$HOST_TARGET" --includedir="${PREFIX_H}"  \
+		--host="${HOST}" --includedir="${PREFIX_H}"  \
 		--prefix="${PREFIX_PROG}" --program-prefix="${PREFIX_PROG}" --libdir="${PREFIX_A}" --bindir="${PREFIX_PROG}" --enable-zlib="$ENABLE_ZLIB" --enable-static \
 		--disable-lastlog --disable-utmp --disable-utmpx --disable-wtmp --disable-wtmpx --disable-harden )
 fi
@@ -61,6 +61,7 @@ make PROGRAMS="dropbear dbclient dropbearkey scp" -C "${PREFIX_DROPBEAR_BUILD}" 
 cp -a "$PREFIX_DROPBEAR_BUILD/dropbearmulti" "$PREFIX_PROG/dropbearmulti"
 
 b_install "$PREFIX_PORTS_INSTALL/dropbearmulti" /usr/bin
+mkdir -p "$PREFIX_ROOTFS/usr/sbin"
 ln -f "$PREFIX_ROOTFS/usr/bin/dropbearmulti" "$PREFIX_ROOTFS/usr/sbin/dropbear"
 ln -f "$PREFIX_ROOTFS/usr/bin/dropbearmulti" "$PREFIX_ROOTFS/usr/bin/dbclient"
 ln -f "$PREFIX_ROOTFS/usr/bin/dropbearmulti" "$PREFIX_ROOTFS/usr/bin/scp"

--- a/dropbear/build.sh
+++ b/dropbear/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/dropbear/patch/0003-autoconf_phoenix.patch
+++ b/dropbear/patch/0003-autoconf_phoenix.patch
@@ -1,0 +1,11 @@
+--- dropbear-2018.76/config.sub	2018-02-27 15:25:10.000000000 +0100
++++ dropbear-2018.76.phoenix/config.sub	2022-12-01 14:26:40.667515381 +0100
+@@ -1376,7 +1376,7 @@
+	      | -os2* | -vos* | -palmos* | -uclinux* | -nucleus* \
+	      | -morphos* | -superux* | -rtmk* | -rtmk-nova* | -windiss* \
+	      | -powermax* | -dnix* | -nx6 | -nx7 | -sei* | -dragonfly* \
+-	      | -skyos* | -haiku* | -rdos* | -toppers* | -drops* | -es*)
++	      | -skyos* | -haiku* | -rdos* | -toppers* | -drops* | -es* | -phoenix*)
+	# Remember, each alternative MUST END IN *, to match a version number.
+		;;
+	-qnx*)

--- a/jansson/build.sh
+++ b/jansson/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/libevent/build.sh
+++ b/libevent/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/lighttpd/build.sh
+++ b/lighttpd/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/lua/build.sh
+++ b/lua/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/lzo/build.sh
+++ b/lzo/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/mbedtls/build.sh
+++ b/mbedtls/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/micropython/build.sh
+++ b/micropython/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/micropython/micropython-1.15-config/patches/04_mpy-cross_Makefile.patch
+++ b/micropython/micropython-1.15-config/patches/04_mpy-cross_Makefile.patch
@@ -22,3 +22,22 @@ diff -Naur micropython-1.15/mpy-cross/Makefile micropython-phoenix/mpy-cross/Mak
  CWARN += -Wextra -Wno-unused-parameter -Wpointer-arith
  CFLAGS = $(INC) $(CWARN) -std=gnu99 $(CFLAGS_MOD) $(COPT) $(CFLAGS_EXTRA)
  CFLAGS += -fdata-sections -ffunction-sections -fno-asynchronous-unwind-tables
+@@ -30,18 +30,7 @@
+ COPT = -Os #-DNDEBUG
+ endif
+
+-# On OSX, 'gcc' is a symlink to clang unless a real gcc is installed.
+-# The unix port of MicroPython on OSX must be compiled with clang,
+-# while cross-compile ports require gcc, so we test here for OSX and
+-# if necessary override the value of 'CC' set in py/mkenv.mk
+-ifeq ($(UNAME_S),Darwin)
+-CC = clang
+-# Use clang syntax for map file
+-LDFLAGS_ARCH = -Wl,-map,$@.map -Wl,-dead_strip
+-else
+-# Use gcc syntax for map file
+ LDFLAGS_ARCH = -Wl,-Map=$@.map,--cref -Wl,--gc-sections
+-endif
+ LDFLAGS = $(LDFLAGS_MOD) $(LDFLAGS_ARCH) -lm $(LDFLAGS_EXTRA)
+
+ # source files

--- a/micropython/micropython-1.15-config/patches/07_os_Makefile.patch
+++ b/micropython/micropython-1.15-config/patches/07_os_Makefile.patch
@@ -10,7 +10,30 @@ diff -Naur micropython-1.15/ports/unix/Makefile micropython-phoenix/ports/unix/M
  CWARN += -Wextra -Wno-unused-parameter -Wpointer-arith -Wdouble-promotion -Wfloat-conversion
  CFLAGS += $(INC) $(CWARN) -std=gnu99 -DUNIX $(CFLAGS_MOD) $(COPT) -I$(VARIANT_DIR) $(CFLAGS_EXTRA)
  
-@@ -238,9 +240,10 @@
+@@ -85,22 +85,8 @@
+ CFLAGS += -U _FORTIFY_SOURCE
+ endif
+
+-# On OSX, 'gcc' is a symlink to clang unless a real gcc is installed.
+-# The unix port of MicroPython on OSX must be compiled with clang,
+-# while cross-compile ports require gcc, so we test here for OSX and
+-# if necessary override the value of 'CC' set in py/mkenv.mk
+-ifeq ($(UNAME_S),Darwin)
+-ifeq ($(MICROPY_FORCE_32BIT),1)
+-CC = clang -m32
+-else
+-CC = clang
+-endif
+-# Use clang syntax for map file
+-LDFLAGS_ARCH = -Wl,-map,$@.map -Wl,-dead_strip
+-else
+ # Use gcc syntax for map file
+ LDFLAGS_ARCH = -Wl,-Map=$@.map,--cref -Wl,--gc-sections
+-endif
+ LDFLAGS += $(LDFLAGS_MOD) $(LDFLAGS_ARCH) -lm $(LDFLAGS_EXTRA)
+
+ # Flags to link with pthread library
+@@ -238,9 +224,10 @@
  	mpbtstackport_usb.c \
  	mpnimbleport.c \
  	$(SRC_MOD) \

--- a/openiked/build.sh
+++ b/openiked/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/openssl/build.sh
+++ b/openssl/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/openvpn/build.sh
+++ b/openvpn/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/pcre/build.sh
+++ b/pcre/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/sscep/build.sh
+++ b/sscep/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/wpa_supplicant/build.sh
+++ b/wpa_supplicant/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/zlib/build.sh
+++ b/zlib/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
These changes bring us closer to being able to compile ports on macOS. Still, some ports do not compile (i.e Azure SDK on ia32-generic-qemu) but the changes will be made in subsequent pull requests. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu - user should be able to compile the entire project with azure sdk disabled.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
