### PR TITLE
build: remove TOPDIR usage

### DIFF
--- a/azure_sdk/build.sh
+++ b/azure_sdk/build.sh
@@ -13,7 +13,7 @@ install_binary () {
 AZURE_VER="lts_01_2022"
 AZURE="azure-iot-sdk-c"
 
-PREFIX_AZURE="${TOPDIR}/phoenix-rtos-ports/azure_sdk"
+PREFIX_AZURE="${PREFIX_PROJECT}/phoenix-rtos-ports/azure_sdk"
 PREFIX_AZURE_BUILD="${PREFIX_BUILD}/azure_sdk"
 PREFIX_AZURE_SRC="${PREFIX_AZURE_BUILD}/${AZURE}-${AZURE_VER}"
 PREFIX_AZURE_MARKERS="${PREFIX_AZURE_BUILD}/markers"

--- a/mbedtls/build.sh
+++ b/mbedtls/build.sh
@@ -8,7 +8,7 @@ MBEDTLS="mbedtls-${MBEDTLS_VER}"
 PKG_URL="https://github.com/Mbed-TLS/mbedtls/archive/v${MBEDTLS_VER}.tar.gz"
 PKG_MIRROR_URL="https://files.phoesys.com/ports/${MBEDTLS}.tar.gz"
 
-PREFIX_MBEDTLS="${TOPDIR}/phoenix-rtos-ports/mbedtls"
+PREFIX_MBEDTLS="${PREFIX_PROJECT}/phoenix-rtos-ports/mbedtls"
 PREFIX_MBEDTLS_BUILD="${PREFIX_BUILD}/mbedtls"
 PREFIX_MBEDTLS_SRC="${PREFIX_MBEDTLS_BUILD}/${MBEDTLS}"
 PREFIX_MBEDTLS_PATCHES="${PREFIX_MBEDTLS}/patches"

--- a/openiked/build.sh
+++ b/openiked/build.sh
@@ -8,7 +8,7 @@ PKG_URL="https://github.com/openiked/openiked-portable/archive/refs/tags/v${OPEN
 PKG_MIRROR_URL="https://files.phoesys.com/ports/${OPENIKED}.tar.gz"
 
 b_log "Building openiked"
-PREFIX_OPENIKED=${TOPDIR}/phoenix-rtos-ports/openiked
+PREFIX_OPENIKED="${PREFIX_PROJECT}/phoenix-rtos-ports/openiked"
 PREFIX_OPENIKED_BUILD=${PREFIX_BUILD}/openiked
 PREFIX_OPENIKED_SRC="${PREFIX_OPENIKED_BUILD}/${OPENIKED}"
 PREFIX_OPENIKED_MARKERS="${PREFIX_OPENIKED_BUILD}/markers"


### PR DESCRIPTION
JIRA: CI-334

`TOPDIR` was obsoleted in favor of `PREFIX_PROJECT`

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
