### PR TITLE
busybox: remove dependency on CLEAN variable

### DIFF
--- a/busybox/build.sh
+++ b/busybox/build.sh
@@ -37,9 +37,9 @@ for patchfile in "$PREFIX_BUSYBOX"/*.patch; do
 done
 
 #
-# Clean and configure
+# Configure
 #
-if [ -n "$CLEAN" ] || [ ! -f "${PREFIX_BUSYBOX_BUILD}/.config" ] || [ "${BUSYBOX_CONFIG}" -nt "${PREFIX_BUSYBOX_BUILD}/.config" ]; then
+if [ ! -f "${PREFIX_BUSYBOX_BUILD}/.config" ] || [ "${BUSYBOX_CONFIG}" -nt "${PREFIX_BUSYBOX_BUILD}/.config" ]; then
 	cp -a "${BUSYBOX_CONFIG}" "${PREFIX_BUSYBOX_BUILD}"/.config
 	make -C "${PREFIX_BUSYBOX_BUILD}" KBUILD_SRC="$PREFIX_BUSYBOX_SRC" -f "${PREFIX_BUSYBOX_SRC}"/Makefile CROSS_COMPILE="$CROSS" CONFIG_PREFIX="$PREFIX_FS/root" clean
 fi


### PR DESCRIPTION
CI to pass: https://github.com/phoenix-rtos/phoenix-rtos-project/pull/815


<!--- Provide a general summary of your changes in the Title above -->

## Description
`clean` is being handled globally (whole build dir is being removed) 

## Motivation and Context
JIRA: CI-334

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
