### PR TITLE
lighttpd: Fix mod_wstunnel not being built in static build

### DIFF
--- a/lighttpd/patches/makefile_wstunnel.patch
+++ b/lighttpd/patches/makefile_wstunnel.patch
@@ -1,0 +1,102 @@
+diff -Naur lighttpd-1.4.53/src/Makefile.in lighttpd-1.4.53.phx/src/Makefile.in
+--- lighttpd-1.4.53/src/Makefile.in	2019-01-27 10:22:29.000000000 +0100
++++ lighttpd-1.4.53.phx/src/Makefile.in	2023-12-18 12:54:52.292092353 +0100
+@@ -678,12 +678,12 @@
+ 	mod_setenv.c mod_simple_vhost.c mod_ssi_exprparser.c \
+ 	mod_ssi_expr.c mod_ssi.c mod_staticfile.c mod_status.c \
+ 	mod_uploadprogress.c mod_userdir.c mod_usertrack.c \
+-	mod_vhostdb.c mod_webdav.c mod_geoip.c mod_cml.c mod_cml_lua.c \
+-	mod_cml_funcs.c mod_magnet.c mod_magnet_cache.c \
+-	mod_authn_gssapi.c mod_authn_ldap.c mod_vhostdb_ldap.c \
+-	mod_authn_pam.c mod_authn_mysql.c mod_mysql_vhost.c \
+-	mod_vhostdb_mysql.c mod_vhostdb_pgsql.c mod_vhostdb_dbi.c \
+-	mod_openssl.c mod_trigger_b4_dl.c
++	mod_vhostdb.c mod_webdav.c mod_wstunnel.c mod_geoip.c \
++	mod_cml.c mod_cml_lua.c mod_cml_funcs.c mod_magnet.c \
++	mod_magnet_cache.c mod_authn_gssapi.c mod_authn_ldap.c \
++	mod_vhostdb_ldap.c mod_authn_pam.c mod_authn_mysql.c \
++	mod_mysql_vhost.c mod_vhostdb_mysql.c mod_vhostdb_pgsql.c \
++	mod_vhostdb_dbi.c mod_openssl.c mod_trigger_b4_dl.c
+ am__objects_2 = lighttpd-base64.$(OBJEXT) lighttpd-buffer.$(OBJEXT) \
+ 	lighttpd-burl.$(OBJEXT) lighttpd-log.$(OBJEXT) \
+ 	lighttpd-http_header.$(OBJEXT) lighttpd-http_kv.$(OBJEXT) \
+@@ -768,6 +768,7 @@
+ @LIGHTTPD_STATIC_TRUE@	lighttpd-mod_usertrack.$(OBJEXT) \
+ @LIGHTTPD_STATIC_TRUE@	lighttpd-mod_vhostdb.$(OBJEXT) \
+ @LIGHTTPD_STATIC_TRUE@	lighttpd-mod_webdav.$(OBJEXT) \
++@LIGHTTPD_STATIC_TRUE@	lighttpd-mod_wstunnel.$(OBJEXT) \
+ @LIGHTTPD_STATIC_TRUE@	$(am__objects_5) $(am__objects_6) \
+ @LIGHTTPD_STATIC_TRUE@	$(am__objects_7) $(am__objects_8) \
+ @LIGHTTPD_STATIC_TRUE@	$(am__objects_9) $(am__objects_10) \
+@@ -1035,6 +1036,7 @@
+ 	./$(DEPDIR)/lighttpd-mod_vhostdb_mysql.Po \
+ 	./$(DEPDIR)/lighttpd-mod_vhostdb_pgsql.Po \
+ 	./$(DEPDIR)/lighttpd-mod_webdav.Po \
++	./$(DEPDIR)/lighttpd-mod_wstunnel.Po \
+ 	./$(DEPDIR)/lighttpd-network.Po \
+ 	./$(DEPDIR)/lighttpd-network_write.Po \
+ 	./$(DEPDIR)/lighttpd-plugin.Po ./$(DEPDIR)/lighttpd-rand.Po \
+@@ -1659,12 +1664,12 @@
+ @LIGHTTPD_STATIC_TRUE@	mod_staticfile.c mod_status.c \
+ @LIGHTTPD_STATIC_TRUE@	mod_uploadprogress.c mod_userdir.c \
+ @LIGHTTPD_STATIC_TRUE@	mod_usertrack.c mod_vhostdb.c \
+-@LIGHTTPD_STATIC_TRUE@	mod_webdav.c $(am__append_16) \
+-@LIGHTTPD_STATIC_TRUE@	$(am__append_18) $(am__append_21) \
+-@LIGHTTPD_STATIC_TRUE@	$(am__append_23) $(am__append_25) \
+-@LIGHTTPD_STATIC_TRUE@	$(am__append_27) $(am__append_30) \
+-@LIGHTTPD_STATIC_TRUE@	$(am__append_33) $(am__append_36) \
+-@LIGHTTPD_STATIC_TRUE@	$(am__append_41)
++@LIGHTTPD_STATIC_TRUE@	mod_webdav.c mod_wstunnel.c \
++@LIGHTTPD_STATIC_TRUE@	$(am__append_16) $(am__append_18) \
++@LIGHTTPD_STATIC_TRUE@	$(am__append_21) $(am__append_23) \
++@LIGHTTPD_STATIC_TRUE@	$(am__append_25) $(am__append_27) \
++@LIGHTTPD_STATIC_TRUE@	$(am__append_30) $(am__append_33) \
++@LIGHTTPD_STATIC_TRUE@	$(am__append_36) $(am__append_41)
+ @LIGHTTPD_STATIC_FALSE@lighttpd_CPPFLAGS = $(FAM_CFLAGS) $(LIBEV_CFLAGS)
+ @LIGHTTPD_STATIC_TRUE@lighttpd_CPPFLAGS = -DLIGHTTPD_STATIC \
+ @LIGHTTPD_STATIC_TRUE@	$(XML_CFLAGS) $(SQLITE_CFLAGS) \
+@@ -2213,6 +2218,7 @@
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/lighttpd-mod_vhostdb_mysql.Po@am__quote@ # am--include-marker
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/lighttpd-mod_vhostdb_pgsql.Po@am__quote@ # am--include-marker
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/lighttpd-mod_webdav.Po@am__quote@ # am--include-marker
++@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/lighttpd-mod_wstunnel.Po@am__quote@ # am--include-marker
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/lighttpd-network.Po@am__quote@ # am--include-marker
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/lighttpd-network_write.Po@am__quote@ # am--include-marker
+ @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/lighttpd-plugin.Po@am__quote@ # am--include-marker
+@@ -3865,6 +3871,20 @@
+ @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+ @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(lighttpd_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o lighttpd-mod_webdav.obj `if test -f 'mod_webdav.c'; then $(CYGPATH_W) 'mod_webdav.c'; else $(CYGPATH_W) '$(srcdir)/mod_webdav.c'; fi`
+ 
++lighttpd-mod_wstunnel.o: mod_wstunnel.c
++@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(lighttpd_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT lighttpd-mod_wstunnel.o -MD -MP -MF $(DEPDIR)/lighttpd-mod_wstunnel.Tpo -c -o lighttpd-mod_wstunnel.o `test -f 'mod_wstunnel.c' || echo '$(srcdir)/'`mod_wstunnel.c
++@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/lighttpd-mod_wstunnel.Tpo $(DEPDIR)/lighttpd-mod_wstunnel.Po
++@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='mod_wstunnel.c' object='lighttpd-mod_wstunnel.o' libtool=no @AMDEPBACKSLASH@
++@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
++@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(lighttpd_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o lighttpd-mod_wstunnel.o `test -f 'mod_wstunnel.c' || echo '$(srcdir)/'`mod_wstunnel.c
++
++lighttpd-mod_wstunnel.obj: mod_wstunnel.c
++@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(lighttpd_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT lighttpd-mod_wstunnel.obj -MD -MP -MF $(DEPDIR)/lighttpd-mod_wstunnel.Tpo -c -o lighttpd-mod_wstunnel.obj `if test -f 'mod_wstunnel.c'; then $(CYGPATH_W) 'mod_wstunnel.c'; else $(CYGPATH_W) '$(srcdir)/mod_wstunnel.c'; fi`
++@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/lighttpd-mod_wstunnel.Tpo $(DEPDIR)/lighttpd-mod_wstunnel.Po
++@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='mod_wstunnel.c' object='lighttpd-mod_wstunnel.obj' libtool=no @AMDEPBACKSLASH@
++@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
++@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(lighttpd_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o lighttpd-mod_wstunnel.obj `if test -f 'mod_wstunnel.c'; then $(CYGPATH_W) 'mod_wstunnel.c'; else $(CYGPATH_W) '$(srcdir)/mod_wstunnel.c'; fi`
++
+ lighttpd-mod_geoip.o: mod_geoip.c
+ @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(lighttpd_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT lighttpd-mod_geoip.o -MD -MP -MF $(DEPDIR)/lighttpd-mod_geoip.Tpo -c -o lighttpd-mod_geoip.o `test -f 'mod_geoip.c' || echo '$(srcdir)/'`mod_geoip.c
+ @am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/lighttpd-mod_geoip.Tpo $(DEPDIR)/lighttpd-mod_geoip.Po
+@@ -4480,6 +4502,7 @@
+ 	-rm -f ./$(DEPDIR)/lighttpd-mod_vhostdb_mysql.Po
+ 	-rm -f ./$(DEPDIR)/lighttpd-mod_vhostdb_pgsql.Po
+ 	-rm -f ./$(DEPDIR)/lighttpd-mod_webdav.Po
++	-rm -f ./$(DEPDIR)/lighttpd-mod_wstunnel.Po
+ 	-rm -f ./$(DEPDIR)/lighttpd-network.Po
+ 	-rm -f ./$(DEPDIR)/lighttpd-network_write.Po
+ 	-rm -f ./$(DEPDIR)/lighttpd-plugin.Po
+@@ -4747,6 +4770,7 @@
+ 	-rm -f ./$(DEPDIR)/lighttpd-mod_vhostdb_mysql.Po
+ 	-rm -f ./$(DEPDIR)/lighttpd-mod_vhostdb_pgsql.Po
+ 	-rm -f ./$(DEPDIR)/lighttpd-mod_webdav.Po
++	-rm -f ./$(DEPDIR)/lighttpd-mod_wstunnel.Po
+ 	-rm -f ./$(DEPDIR)/lighttpd-network.Po
+ 	-rm -f ./$(DEPDIR)/lighttpd-network_write.Po
+ 	-rm -f ./$(DEPDIR)/lighttpd-plugin.Po


### PR DESCRIPTION
WARN: only Makefile.in changed without Makefile.am to avoid necessary autogen run.

JIRA: DTR-460

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
