### PR TITLE
busybox: fix ash segfaults after interrupting applet

### DIFF
--- a/busybox/20-fix-ash-nofork-interrupted.patch
+++ b/busybox/20-fix-ash-nofork-interrupted.patch
@@ -1,0 +1,23 @@
+diff --git a/shell/ash.c b/shell/ash.c
+--- a/shell/ash.c
++++ b/shell/ash.c
+@@ -9745,9 +9745,18 @@ evalcommand(union node *cmd, int flags)
+ 		/* find_command() encodes applet_no as (-2 - applet_no) */
+ 		int applet_no = (- cmdentry.u.index - 2);
+ 		if (applet_no >= 0 && APPLET_IS_NOFORK(applet_no)) {
++			INT_OFF;
+ 			listsetvar(varlist.list, VEXPORT|VSTACK);
+-			/* run <applet>_main() */
++			/*
++			 * Run <applet>_main().
++			 * Signals (^C) can't interrupt here.
++			 * Otherwise we can mangle stdio or malloc internal state.
++			 * This makes applets which can run for a long time
++			 * and/or wait for user input ineligible for NOFORK:
++			 * for example, "yes" or "rm" (rm -i waits for input).
++			 */
+ 			status = run_nofork_applet(applet_no, argv);
++			INT_ON;
+ 			break;
+ 		}
+ #endif


### PR DESCRIPTION
Backported fix from Busybox v1.36.

## Description
If certain applets in `ash` are interrupted with `^C` it could cause a corruption of the system state, which causes all subsequent commands to cause segfaults. This has been fixed in later versions of Busybox and this PR backports the fix.

## Motivation and Context
Closes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/890

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a9-zynq7000-qemu, ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
