### PR TITLE
mbedtls: remove extra whitespaces from patches

### DIFF
--- a/mbedtls/patches/02_rename_debug_var.patch
+++ b/mbedtls/patches/02_rename_debug_var.patch
@@ -7,6 +7,6 @@ diff -ur '--exclude=*.git' mbedtls-2.28.0/programs/ssl/ssl_context_info.c mbedtl
  char conf_dtls_proto = 1;               /* MBEDTLS_SSL_PROTO_DTLS from mbedTLS configuration */
 -char debug = 0;                         /* flag for debug messages */
 +/* 'debug' has been already defined as syscall in Phoenix-RTOS */
-+static char debug = 0;                         /* flag for debug messages */
++static char debug = 0;                  /* flag for debug messages */
  const char alloc_err[] = "Cannot allocate memory\n";
  const char buf_ln_err[] = "Buffer does not have enough data to complete the parsing\n";

--- a/mbedtls/patches/04_set_devrandom_entropy.patch
+++ b/mbedtls/patches/04_set_devrandom_entropy.patch
@@ -6,11 +6,11 @@ diff -ur '--exclude=*.git' mbedtls-2.28.0/include/mbedtls/config.h mbedtls-2.28.
  
  /**
 + * \def MBEDTLS_ENTROPY_DEV_RANDOM
-+ * 
++ *
 + * Uncomment this macro to let mbed TLS use /dev/random as entropy source.
-+ * 
++ *
 + * If /dev/random is not present in file system it will not be used.
-+ * 
++ *
 + */
 +#define MBEDTLS_ENTROPY_DEV_RANDOM
 +
@@ -85,7 +85,7 @@ diff -ur '--exclude=*.git' mbedtls-2.28.0/library/entropy_poll.c mbedtls-2.28.0-
 +        return( MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
 +
 +    ret = fread( p, 1, len, file );
-+    if( ret == 0 && ferror( file ) ) 
++    if( ret == 0 && ferror( file ) )
 +    {
 +        fclose( file );
 +        return( MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );


### PR DESCRIPTION
JIRA: RTOS-1067

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
~~For host-generic platform, when `phoenix` is not defined, projects didn't build because `mbedtls_devrandom_poll()` was undeclared. I don't know if it's ok to allow using /dev/random for other OSs, so I moved `#if defined(phoenix)` clause over `MBEDTLS_ENTROPY_DEV_RANDOM`.~~

I ~~also~~ deleted some trailing/unneeded spaces.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
~~Needed for compiling phoenix-rtos projects with mbedtls on host~~

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
