### PR TITLE
Update build scripts to be compatible with strip.py wrapper

### DIFF
--- a/azure_sdk/build.sh
+++ b/azure_sdk/build.sh
@@ -6,7 +6,7 @@ install_binary () {
 	BINARY_NAME="$(basename "$1")"
 
 	cp "$1" "${PREFIX_PROG}"
-	$STRIP "${PREFIX_PROG}/${BINARY_NAME}" -o "$PREFIX_PROG_STRIPPED/${BINARY_NAME}"
+	$STRIP  -o "$PREFIX_PROG_STRIPPED/${BINARY_NAME}" "${PREFIX_PROG}/${BINARY_NAME}"
 	b_install "${PREFIX_PROG_STRIPPED}/${BINARY_NAME}" /bin
 }
 

--- a/coremark/build.sh
+++ b/coremark/build.sh
@@ -59,5 +59,5 @@ export XCFLAGS="${CFLAGS} -DUSE_PTHREAD -DMULTITHREAD=${PORTS_COREMARK_THREADS} 
 PORT_DIR=phoenix make compile
 
 cp -a "$PREFIX_COREMARK_BUILD/${COREMARK}/coremark" "$PREFIX_PROG/coremark"
-$STRIP -s "${PREFIX_PROG}/coremark" -o "${PREFIX_PROG_STRIPPED}/coremark"
+$STRIP -o "${PREFIX_PROG_STRIPPED}/coremark" "${PREFIX_PROG}/coremark"
 b_install "$PREFIX_PORTS_INSTALL/coremark" /bin

--- a/curl/build.sh
+++ b/curl/build.sh
@@ -42,5 +42,5 @@ make -C "$PREFIX_CURL_BUILD" install
 cp -a "$PREFIX_CURL_INSTALL/include/curl" "$PREFIX_H"
 cp -a "$PREFIX_CURL_INSTALL/lib/"* "$PREFIX_A"
 cp -a "$PREFIX_CURL_INSTALL/bin/curl" "$PREFIX_PROG/curl"
-$STRIP -s "$PREFIX_PROG/curl" -o "$PREFIX_PROG_STRIPPED/curl"
+$STRIP -o "$PREFIX_PROG_STRIPPED/curl" "$PREFIX_PROG/curl"
 b_install "$PREFIX_PORTS_INSTALL/curl" /usr/bin/

--- a/dropbear/build.sh
+++ b/dropbear/build.sh
@@ -58,7 +58,7 @@ fi
 # create multi-binary and hardlinks
 make PROGRAMS="dropbear dbclient dropbearkey scp" -C "${PREFIX_DROPBEAR_BUILD}" CROSS_COMPILE="$CROSS" MULTI=1 NO_ADDTL_WARNINGS=1
 
-$STRIP -s "$PREFIX_DROPBEAR_BUILD/dropbearmulti" -o "$PREFIX_PROG_STRIPPED/dropbearmulti"
+$STRIP -o "$PREFIX_PROG_STRIPPED/dropbearmulti" "$PREFIX_DROPBEAR_BUILD/dropbearmulti"
 cp -a "$PREFIX_DROPBEAR_BUILD/dropbearmulti" "$PREFIX_PROG/dropbearmulti"
 
 b_install "$PREFIX_PORTS_INSTALL/dropbearmulti" /usr/bin

--- a/fs_mark/build.sh
+++ b/fs_mark/build.sh
@@ -43,5 +43,5 @@ done
 cd "${PREFIX_FS_MARK_BUILD}/${FS_MARK}" && make
 
 cp -a "$PREFIX_FS_MARK_BUILD/${FS_MARK}/fs_mark" "$PREFIX_PROG/fs_mark"
-$STRIP -s "${PREFIX_PROG}/fs_mark" -o "${PREFIX_PROG_STRIPPED}/fs_mark"
+$STRIP -o "${PREFIX_PROG_STRIPPED}/fs_mark" "${PREFIX_PROG}/fs_mark"
 b_install "$PREFIX_PORTS_INSTALL/fs_mark" /bin

--- a/lighttpd/build.sh
+++ b/lighttpd/build.sh
@@ -65,5 +65,5 @@ fi
 
 make -C "${PREFIX_LIGHTTPD_BUILD}" install
 
-$STRIP -s "$PREFIX_PROG/lighttpd" -o "$PREFIX_PROG_STRIPPED/lighttpd"
+$STRIP -o "$PREFIX_PROG_STRIPPED/lighttpd" "$PREFIX_PROG/lighttpd"
 b_install "$PREFIX_PORTS_INSTALL/lighttpd" /usr/sbin

--- a/lua/build.sh
+++ b/lua/build.sh
@@ -26,8 +26,8 @@ fi
 # FIXME: no out-of-tree building
 make -C "$PREFIX_LUA_SRC" posix
 
-$STRIP -s "$PREFIX_LUA_SRC/src/lua" -o "$PREFIX_PROG_STRIPPED/lua"
-$STRIP -s "$PREFIX_LUA_SRC/src/luac" -o "$PREFIX_PROG_STRIPPED/luac"
+$STRIP -o "$PREFIX_PROG_STRIPPED/lua" "$PREFIX_LUA_SRC/src/lua"
+$STRIP -o "$PREFIX_PROG_STRIPPED/luac" "$PREFIX_LUA_SRC/src/luac"
 cp -a "$PREFIX_LUA_SRC/src/lua" "$PREFIX_PROG/lua"
 cp -a "$PREFIX_LUA_SRC/src/luac" "$PREFIX_PROG/luac"
 

--- a/openiked/build.sh
+++ b/openiked/build.sh
@@ -54,7 +54,7 @@ popd
 
 cp -a "${PREFIX_OPENIKED_INSTALL}/usr/local/sbin/ikectl" "${PREFIX_PROG}/ikectl"
 cp -a "${PREFIX_OPENIKED_INSTALL}/usr/local/sbin/iked" "${PREFIX_PROG}/iked"
-$STRIP -s "${PREFIX_PROG}/ikectl" -o "${PREFIX_PROG_STRIPPED}/ikectl"
-$STRIP -s "${PREFIX_PROG}/iked" -o "${PREFIX_PROG_STRIPPED}/iked"
+$STRIP -o "${PREFIX_PROG_STRIPPED}/ikectl" "${PREFIX_PROG}/ikectl"
+$STRIP -o "${PREFIX_PROG_STRIPPED}/iked" "${PREFIX_PROG}/iked"
 b_install "${PREFIX_PORTS_INSTALL}/ikectl" /usr/bin
 b_install "${PREFIX_PORTS_INSTALL}/iked" /usr/bin

--- a/openssl/build.sh
+++ b/openssl/build.sh
@@ -57,5 +57,5 @@ cp -a "$PREFIX_OPENSSL_INSTALL/lib/pkgconfig" "$PREFIX_A"
 sed -i "s/openssl\/install$/lib\/pkgconfg/" "$PREFIX_A/pkgconfig/"*
 
 cp -a "$PREFIX_OPENSSL_INSTALL/bin/openssl"  "$PREFIX_PROG"
-$STRIP -s "$PREFIX_PROG/openssl" -o "$PREFIX_PROG_STRIPPED/openssl"
+$STRIP -o "$PREFIX_PROG_STRIPPED/openssl" "$PREFIX_PROG/openssl"
 b_install "$PREFIX_PORTS_INSTALL/openssl" /usr/bin/

--- a/openvpn/build.sh
+++ b/openvpn/build.sh
@@ -49,5 +49,5 @@ fi
 make -C "$PREFIX_OPENVPN_BUILD"
 make -C "$PREFIX_OPENVPN_BUILD" install-exec
 
-$STRIP -s "$PREFIX_PROG/openvpn" -o "$PREFIX_PROG_STRIPPED/openvpn"
+$STRIP -o "$PREFIX_PROG_STRIPPED/openvpn" "$PREFIX_PROG/openvpn"
 b_install "$PREFIX_PORTS_INSTALL/openvpn" /sbin/

--- a/picocom/build.sh
+++ b/picocom/build.sh
@@ -47,7 +47,7 @@ export LDFLAGS="${CFLAGS} $LDFLAGS"
 #
 (cd "${PREFIX_PCOM_SRC}" && make clean && make)
 cp -a "${PREFIX_PCOM_SRC}/picocom" "$PREFIX_PROG"
-$STRIP -s "${PREFIX_PROG}/picocom" -o "$PREFIX_PROG_STRIPPED/picocom"
+$STRIP -o "$PREFIX_PROG_STRIPPED/picocom" "${PREFIX_PROG}/picocom"
 
 
 b_install "${PREFIX_PROG_STRIPPED}/picocom" /bin

--- a/sscep/build.sh
+++ b/sscep/build.sh
@@ -51,5 +51,5 @@ make install DESTDIR="$PREFIX_SSCEP_INSTALL"
 popd
 
 cp -a "${PREFIX_SSCEP_INSTALL}/bin/sscep" "${PREFIX_PROG}/sscep"
-$STRIP -s "${PREFIX_PROG}/sscep" -o "${PREFIX_PROG_STRIPPED}/sscep"
+$STRIP -o "${PREFIX_PROG_STRIPPED}/sscep" "${PREFIX_PROG}/sscep"
 b_install "${PREFIX_PORTS_INSTALL}/sscep" /usr/bin

--- a/wpa_supplicant/build.sh
+++ b/wpa_supplicant/build.sh
@@ -50,7 +50,7 @@ popd
 
 cp -a "${PREFIX_WPA_SUPPLICANT_INSTALL}/bin/wpa_cli" "${PREFIX_PROG}/wpa_cli"
 cp -a "${PREFIX_WPA_SUPPLICANT_INSTALL}/bin/wpa_supplicant" "${PREFIX_PROG}/wpa_supplicant"
-$STRIP -s "${PREFIX_PROG}/wpa_cli" -o "${PREFIX_PROG_STRIPPED}/wpa_cli"
-$STRIP -s "${PREFIX_PROG}/wpa_supplicant" -o "${PREFIX_PROG_STRIPPED}/wpa_supplicant"
+$STRIP -o "${PREFIX_PROG_STRIPPED}/wpa_cli" "${PREFIX_PROG}/wpa_cli"
+$STRIP -o "${PREFIX_PROG_STRIPPED}/wpa_supplicant" "${PREFIX_PROG}/wpa_supplicant"
 b_install "${PREFIX_PORTS_INSTALL}/wpa_cli" /usr/bin
 b_install "${PREFIX_PORTS_INSTALL}/wpa_supplicant" /usr/bin


### PR DESCRIPTION
Some architectures, like armv7m, use a wrapper script for strip which expects specific arguments at the end. This change makes ports use strip in a specific manner so that they build properly on all architectures. The `-s` (`--strip-all`) flag is removed, as it probably is not appropriate for all architectures (which use their own symbol stripping flags) and seems to be the default action when no flag is passed.

Another approach is to modify phoenix-rtos-build/scripts/strip.py to behave just like the `strip` tool, but it is also quite problematical.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
