### PR TITLE
lsb_vsx: fix testcase 1 of fstat

### DIFF
--- a/lsb_vsx/patches/ps_VSX/16_fstat.patch
+++ b/lsb_vsx/patches/ps_VSX/16_fstat.patch
@@ -1,22 +1,53 @@
---- lsb_vsx/test_sets/tset/POSIX.os/files/fstat/fstat.c	2024-10-16 15:22:06.485884602 +0200
-+++ lsb_vsx.phoenix/test_sets/tset/POSIX.os/files/fstat/fstat.c	2024-10-16 15:22:06.485884602 +0200
-@@ -276,14 +276,15 @@
- 	t1f();
- 	PATH_FUNC_TRACE;
+--- lsb_vsx.host/test_sets/tset/POSIX.os/files/fstat/fstat.c	2026-02-10 17:29:53.518575114 +0100
++++ lsb_vsx.phoenix/test_sets/tset/POSIX.os/files/fstat/fstat.c	2026-02-10 17:30:06.976494145 +0100
+@@ -336,6 +336,25 @@
  
--	globok = 0;
--	t1g();
--	PATH_FUNC_TRACE;
-+/* Issue: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1245 */
-+	// globok = 0;
-+	// t1g();
-+	// PATH_FUNC_TRACE;
+ 	(void) sleep(2);
  
- #endif	/* TEST_XNFS */
++/* Move t1 capture before write() to avoid testcase failure */
++#if        TEST_XNFS
++
++        if (xnfs_rtime_c(&t1, SP_T1_RTIME2_START) != 0)
++        {
++                xx_rpt(DELETION);
++                in_rpt("could not obtain current time on server");
++                DBUG_VOID_RETURN;
++        }
++        else
++                PATH_TRACE;
++
++#else   /* TEST_XNFS */
++
++        (void) time(&t1);
++        PATH_TRACE;
++
++#endif  /* TEST_XNFS */
++
+ 	if (write(fd, wbuf, (unsigned)sizeof(wbuf)) != sizeof(wbuf))
+ 	{
+ 		err = errno;
+@@ -351,24 +370,6 @@
  
- 	if (testfail == 0)
--		PATH_XS_RPT(7);
-+		PATH_XS_RPT(6);
+ 	(void) close(fd);
  
- 	DBUG_VOID_RETURN;
- }
+-#if	   TEST_XNFS
+-
+-	if (xnfs_rtime_c(&t1, SP_T1_RTIME2_START) != 0)
+-	{
+-		xx_rpt(DELETION);
+-		in_rpt("could not obtain current time on server");
+-		DBUG_VOID_RETURN;
+-	}
+-	else
+-		PATH_TRACE;
+-
+-#else	/* TEST_XNFS */
+-
+-	(void) time(&t1);
+-	PATH_TRACE;
+-
+-#endif	/* TEST_XNFS */
+-
+ 	(void) sleep(1);
+ 
+ 	if (stat(".", &stbuf) == SYSERROR)


### PR DESCRIPTION
JIRA: CI-524

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
In the test, t1 is recorded after writing to the file. If the write occurs near the end of a second (e.g., 0.99s), the file’s st_mtime will be set to that second (0). Later, time(&t1) may return the next second (e.g., 1). The test then checks if st_mtime == t1 || t1+1 || t1+2, which can fail because st_mtime is actually earlier than t1. If t1 were collected before the write, the comparison would correctly account for the modification time, avoiding this race condition.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
