### PR TITLE
patch: add patch to plugin-static.h file - mod_dirlisting and mod_sta…

### DIFF
--- a/lighttpd/patches/plugin_static_fix.patch
+++ b/lighttpd/patches/plugin_static_fix.patch
@@ -1,0 +1,9 @@
+--- a/src/plugin-static.h	2025-04-11 14:53:38.273126650 +0200
++++ b/src/plugin-static.h	2025-04-11 14:53:25.491193904 +0200
+@@ -1,4 +1,6 @@
+ PLUGIN_INIT(mod_indexfile)
++PLUGIN_INIT(mod_dirlisting)
++PLUGIN_INIT(mod_staticfile)
+ PLUGIN_INIT(mod_access)
+ PLUGIN_INIT(mod_accesslog)
+ PLUGIN_INIT(mod_alias)


### PR DESCRIPTION
…ticfile init.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added patch that includes PLUGIN_INIT of mod_dirlisting and mod_staticfile in file src/plugin-static.h

## Motivation and Context
I couldn't run lighttpd on ia32-generic-qemu target, print-debugging have showed that it is looking for those plugins but they are not included.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: ia32-generic-qemu.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
