### PR TITLE
lsb_vsx: add missing values to ps_vsxparams

### DIFF
--- a/lsb_vsx/build.sh
+++ b/lsb_vsx/build.sh
@@ -255,8 +255,13 @@ if [ ! -f "${PREFIX_LSB_VSX_MARKERS}/ps_VSX/ps_VSX.built" ]; then
 	    -e "s|^INCDIRS=.*$|INCDIRS=\"${PREFIX_PROJECT}/_build/${TARGET}/sysroot/usr/include\"|" \
 	    -e "s|^VSXDIR=.*$|VSXDIR=\"${VSXDIR}\"|" \
 	    -e "s|^TET_EXECUTE=.*$|TET_EXECUTE=\"${TET_EXECUTE}\"|" \
+	    -e "s|^VSX_ORG=.*$|VSX_ORG=\"Phoenix Systems\"|" \
+	    -e "s|^VSX_OPER=.*$|VSX_OPER=\"${USER:-Unknown}\"|" \
 	    -e "s|^VSX_SYS=.*$|VSX_SYS=\"Phoenix-RTOS\"|" \
 	    -e "s|^MLIB=.*$|MLIB=\"\"|" \
+	    -e "s|^SUBSETS=.*$|SUBSETS=\"base\"|" \
+	    -e "s|^RPCLIB=.*$|RPCLIB=\"\"|" \
+	    -e "s|^NOSPC_DEV=.*$|NOSPC_DEV=\"NOSPC_DEV\"|" \
 	"${PREFIX_PORT}/skel/vsxparams" > "${PREFIX_PORT_BUILD}/ps_config/ps_vsxparams"
 
 	apply_patches "ps_VSX"


### PR DESCRIPTION
Fix missing configuration values causing two libraries and multiple tests to fail to build.

JIRA: CI-547

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
