### PR TITLE
micropython: fix exception pagefaults when using GCC 14

### DIFF
--- a/micropython/build.sh
+++ b/micropython/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-UPYTH_VER="1.15"
+UPYTH_VER="1.15" # TODO: on update to 1.23.0+ remove MICROPY_NLR_SETJMP define below
 UPYTH="micropython-${UPYTH_VER}"
 PKG_URL="https://github.com/micropython/micropython/releases/download/v${UPYTH_VER}/${UPYTH}.tar.xz"
 PKG_MIRROR_URL="https://files.phoesys.com/ports/${UPYTH}.tar.xz"
@@ -77,6 +77,10 @@ export CFLAGS_EXTRA="${CFLAGS} -DUPYTH_STACKSZ=${UPYTH_STACKSZ} -DUPYTH_HEAPSZ=$
 # clear original ld-format ldflags/cflags
 export LDFLAGS=""
 export CFLAGS=""
+
+# TODO: Remove when updating micropython to v1.23.0+.
+# Fix for GCC 14, see https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1318
+export CFLAGS_EXTRA="${CFLAGS_EXTRA} -DMICROPY_NLR_SETJMP=1"
 
 
 #


### PR DESCRIPTION
JIRA: CI-544

Temporary fix for GCC 14 compatibility (phoenix-rtos/phoenix-rtos-project#1318), should be removed after updating to 1.23.0 or later. 

For more information check out micropython issue: https://github.com/micropython/micropython/issues/14115

Resolves the same problem as #103 without changing optimization level

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
