### PR TITLE
micropython: fix longjmp pagefaults when using GCC 14

### DIFF
--- a/micropython/build.sh
+++ b/micropython/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-UPYTH_VER="1.15" # TODO: on update to 1.23.0+ remove MICROPY_NLR_SETJMP define below
+UPYTH_VER="1.15"
 UPYTH="micropython-${UPYTH_VER}"
 PKG_URL="https://github.com/micropython/micropython/releases/download/v${UPYTH_VER}/${UPYTH}.tar.xz"
 PKG_MIRROR_URL="https://files.phoesys.com/ports/${UPYTH}.tar.xz"
@@ -77,10 +77,6 @@ export CFLAGS_EXTRA="${CFLAGS} -DUPYTH_STACKSZ=${UPYTH_STACKSZ} -DUPYTH_HEAPSZ=$
 # clear original ld-format ldflags/cflags
 export LDFLAGS=""
 export CFLAGS=""
-
-# TODO: Remove when updating micropython to v1.23.0+.
-# Fix for GCC 14, see https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1318
-export CFLAGS_EXTRA="${CFLAGS_EXTRA} -DMICROPY_NLR_SETJMP=1"
 
 
 #

--- a/micropython/micropython-1.15-config/patches/10_gcc14_nlr.patch
+++ b/micropython/micropython-1.15-config/patches/10_gcc14_nlr.patch
@@ -1,0 +1,83 @@
+Addresses GCC 14 issues https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1318
+Patch is a subset of upstream commit https://github.com/micropython/micropython/commit/35f3f0a
+
+TODO: this patch should be removed after updating to micropython 1.23.0+
+
+diff --git a/py/nlraarch64.c b/py/nlraarch64.c
+index fcc318f2dc182..d6d87ebc50db8 100644
+--- a/py/nlraarch64.c
++++ b/py/nlraarch64.c
+@@ -75,7 +75,7 @@ NORETURN void nlr_jump(void *val) {
+         "ret                     \n"
+         :
+         : "r" (top)
+-        :
++        : "memory"
+         );
+
+     MP_UNREACHABLE
+diff --git a/py/nlrpowerpc.c b/py/nlrpowerpc.c
+index 448459216b6e8..8a69fe1eeca6b 100644
+--- a/py/nlrpowerpc.c
++++ b/py/nlrpowerpc.c
+@@ -114,7 +114,7 @@ NORETURN void nlr_jump(void *val) {
+         "blr ;"
+         :
+         : "r" (&top->regs)
+-        :
++        : "memory"
+         );
+
+     MP_UNREACHABLE;
+diff --git a/py/nlrthumb.c b/py/nlrthumb.c
+index a8ffecc470335..a22c5df5b9418 100644
+--- a/py/nlrthumb.c
++++ b/py/nlrthumb.c
+@@ -132,7 +132,7 @@ NORETURN void nlr_jump(void *val) {
+         "bx     lr                  \n" // return
+         :                           // output operands
+         : "r" (top)                 // input operands
+-        :                           // clobbered registers
++        : "memory"                  // clobbered registers
+         );
+
+     MP_UNREACHABLE
+diff --git a/py/nlrx64.c b/py/nlrx64.c
+index 6b7d0262f5491..d1ad91ff7d718 100644
+--- a/py/nlrx64.c
++++ b/py/nlrx64.c
+@@ -123,7 +123,7 @@ NORETURN void nlr_jump(void *val) {
+         "ret                        \n" // return
+         :                           // output operands
+         : "r" (top)                 // input operands
+-        :                           // clobbered registers
++        : "memory"                  // clobbered registers
+         );
+
+     MP_UNREACHABLE
+diff --git a/py/nlrx86.c b/py/nlrx86.c
+index f658d41910c8d..085e30d2034a1 100644
+--- a/py/nlrx86.c
++++ b/py/nlrx86.c
+@@ -95,7 +95,7 @@ NORETURN void nlr_jump(void *val) {
+         "ret                        \n" // return
+         :                           // output operands
+         : "r" (top)                 // input operands
+-        :                           // clobbered registers
++        : "memory"                  // clobbered registers
+         );
+
+     MP_UNREACHABLE
+diff --git a/py/nlrxtensa.c b/py/nlrxtensa.c
+index abe9042af9f17..ff7af6edeef98 100644
+--- a/py/nlrxtensa.c
++++ b/py/nlrxtensa.c
+@@ -74,7 +74,7 @@ NORETURN void nlr_jump(void *val) {
+         "ret.n                      \n" // return
+         :                           // output operands
+         : "r" (top)                 // input operands
+-        :                           // clobbered registers
++        : "memory"                  // clobbered registers
+         );
+
+     MP_UNREACHABLE


### PR DESCRIPTION
Continuation of phoenix-rtos/phoenix-rtos-project#1318 and #109 
It seems that previous fix introduces another problem with micropython's setjmp exceptions handling.

* reverts a5e3b0d
* applies patch with adjusted upstream fix commit from micropython v1.23.0

JIRA: CI-544

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu (phoenix-rtos-tests/micropython)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
