### PR TITLE
webuav: port smolrtsp library

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -67,6 +67,7 @@ ports=(
 	"coreMQTT"
 	"lsb_vsx"
 	"heatshrink"
+	"smolrtsp"
 )
 
 

--- a/smolrtsp/build.sh
+++ b/smolrtsp/build.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+
+VERSION=0.1.3
+
+PKG_URL="https://github.com/OpenIPC/smolrtsp/archive/refs/tags/v${VERSION}.tar.gz"
+PREFIX_SMOLRTSP_SRC="${PREFIX_PORT_BUILD}/smolrtsp-${VERSION}"
+
+#
+# Download and unpack
+#
+mkdir -p "$PREFIX_PORT_BUILD"
+b_port_download "https://github.com/OpenIPC/smolrtsp/archive/refs/tags/" "v${VERSION}.tar.gz"
+[ -d "$PREFIX_SMOLRTSP_SRC" ] || tar zxf "${PREFIX_PORT}/v${VERSION}.tar.gz" -C "$PREFIX_PORT_BUILD"
+
+#
+# Apply patches
+#
+b_port_apply_patches "$PREFIX_SMOLRTSP_SRC"
+
+#
+# Make
+#
+pushd "$PREFIX_SMOLRTSP_SRC"
+mkdir -p build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX="$PREFIX_BUILD" -DCMAKE_BUILD_TYPE=Release ..
+cmake --build .
+cmake --install .
+popd

--- a/smolrtsp/patches/01-installation.patch
+++ b/smolrtsp/patches/01-installation.patch
@@ -1,0 +1,58 @@
+# Fix: Make library installable and use stable, versioned dependencies.
+diff -ruN a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2025-08-19 09:57:32.296953644 +0200
++++ b/CMakeLists.txt	2025-09-09 10:26:06.053224322 +0200
+@@ -13,23 +13,19 @@
+ 
+ FetchContent_Declare(
+   slice99
+-  GIT_REPOSITORY https://github.com/Hirrolot/slice99
+-  GIT_TAG 7075e1e)
++  URL https://github.com/hirrolot/slice99/archive/refs/tags/v0.7.8.tar.gz)
+ 
+ FetchContent_Declare(
+   metalang99
+-  GIT_REPOSITORY https://github.com/Hirrolot/metalang99
+-  GIT_TAG e0eb4e1)
++  URL https://github.com/hirrolot/metalang99/archive/refs/tags/v1.13.5.tar.gz)
+ 
+ FetchContent_Declare(
+   datatype99
+-  GIT_REPOSITORY https://github.com/Hirrolot/datatype99
+-  GIT_TAG aa24712)
++  URL https://github.com/hirrolot/datatype99/archive/refs/tags/v1.6.5.tar.gz)
+ 
+ FetchContent_Declare(
+   interface99
+-  GIT_REPOSITORY https://github.com/Hirrolot/interface99
+-  GIT_TAG 73c7c1e)
++  URL https://github.com/hirrolot/interface99/archive/refs/tags/v1.0.2.tar.gz)
+ 
+ FetchContent_MakeAvailable(slice99 datatype99 interface99)
+ 
+@@ -135,3 +131,25 @@
+ target_link_libraries(${PROJECT_NAME} PUBLIC slice99 metalang99 datatype99 interface99)
+ 
+ set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 99 C_STANDARD_REQUIRED ON)
++
++install(
++    TARGETS smolrtsp
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
++)
++
++install(
++    DIRECTORY ${PROJECT_SOURCE_DIR}/include/
++    DESTINATION ${CMAKE_INSTALL_PREFIX}/include
++)
++
++FetchContent_GetProperties(slice99 SOURCE_DIR SLICE99_SOURCE_DIR)
++install(FILES ${SLICE99_SOURCE_DIR}/slice99.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
++
++FetchContent_GetProperties(metalang99 SOURCE_DIR METALANG99_SOURCE_DIR)
++install(DIRECTORY ${METALANG99_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
++
++FetchContent_GetProperties(datatype99 SOURCE_DIR DATATYPE99_SOURCE_DIR)
++install(FILES ${DATATYPE99_SOURCE_DIR}/datatype99.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
++
++FetchContent_GetProperties(interface99 SOURCE_DIR INTERFACE99_SOURCE_DIR)
++install(FILES ${INTERFACE99_SOURCE_DIR}/interface99.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)

--- a/smolrtsp/patches/02-ip_pmtudisc_want.patch
+++ b/smolrtsp/patches/02-ip_pmtudisc_want.patch
@@ -1,0 +1,13 @@
+# problem: IP_PMTUDISC_WANT undefined on phoenix-rtos
+diff -ruN a/src/transport/udp.c b/src/transport/udp.c
+--- a/src/transport/udp.c	2025-08-19 10:13:41.341623698 +0200
++++ b/src/transport/udp.c	2025-08-19 10:14:09.342016325 +0200
+@@ -106,7 +106,7 @@
+ 
+     const int enable_pmtud = 1;
+     if (setsockopt(
+-            fd, IPPROTO_IP, IP_PMTUDISC_WANT, &enable_pmtud,
++            fd, IPPROTO_IP, 0, &enable_pmtud,
+             sizeof enable_pmtud) == -1) {
+         perror("setsockopt IP_PMTUDISC_WANT");
+         goto fail;


### PR DESCRIPTION
JIRA: PP-332

Add `smolrtsp` library port for streaming server

## Description

Adds a port for the `smolrtsp` library. 

This library is a required dependency for the streaming server application, which is located in a separate submodule.

## Motivation and Context

The streaming server application requires the `smolrtsp` library to handle the RTSP protocol.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

## How Has This Been Tested?

The change has been manually tested. 

The server submodule builds and links successfully against the `smolrtsp` library. 

The server application starts, its streaming component initializes without errors, and the video streams correctly.

- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `host-generic`, `ia32-generic`, `armv7a9-zynq7000`

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
