### PR TITLE
smolrtsp: fix udp functionality

### DIFF
--- a/smolrtsp/patches/02-ip_pmtudisc_want.patch
+++ b/smolrtsp/patches/02-ip_pmtudisc_want.patch
@@ -1,13 +1,19 @@
 # problem: IP_PMTUDISC_WANT undefined on phoenix-rtos
 diff -ruN a/src/transport/udp.c b/src/transport/udp.c
 --- a/src/transport/udp.c	2025-08-19 10:13:41.341623698 +0200
-+++ b/src/transport/udp.c	2025-08-19 10:14:09.342016325 +0200
-@@ -106,7 +106,7 @@
- 
-     const int enable_pmtud = 1;
-     if (setsockopt(
--            fd, IPPROTO_IP, IP_PMTUDISC_WANT, &enable_pmtud,
-+            fd, IPPROTO_IP, 0, &enable_pmtud,
-             sizeof enable_pmtud) == -1) {
-         perror("setsockopt IP_PMTUDISC_WANT");
++++ b/src/transport/udp.c	2025-09-29 09:26:49.622229888 +0200
+@@ -104,14 +104,6 @@
          goto fail;
+     }
+ 
+-    const int enable_pmtud = 1;
+-    if (setsockopt(
+-            fd, IPPROTO_IP, IP_PMTUDISC_WANT, &enable_pmtud,
+-            sizeof enable_pmtud) == -1) {
+-        perror("setsockopt IP_PMTUDISC_WANT");
+-        goto fail;
+-    }
+-
+     return fd;
+ 
+ fail:


### PR DESCRIPTION
JIRA: PP-332

Fix UDP functionality.

## Description
Remove unsupported feature from the library.

## Motivation and Context
Phoenix-RTOS does not implement the IP_PMTUDISC_WANT socket option.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

## How Has This Been Tested?
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
