### PR TITLE
heatshrink: mkdir `${PREFIX_PORT_INSTALL}/bin/` before make

### DIFF
--- a/heatshrink/port.def.sh
+++ b/heatshrink/port.def.sh
@@ -36,6 +36,7 @@ p_prepare() {
 }
 
 p_build() {
+	mkdir -p "${PREFIX_PORT_INSTALL}/bin/"
 	make -C "${PREFIX_PORT_WORKDIR}" install PREFIX="$PREFIX_PORT_INSTALL" OPTIMIZE="-Os"
 
 	cp -a "${PREFIX_PORT_INSTALL}/bin/"* "$PREFIX_PROG"


### PR DESCRIPTION
Makefile for heatshrink assumes `$PREFIX/bin` to already exist. Lack of mkdir is an oversight introduced during port migration to port.def.sh.

JIRA: RTOS-1263

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
