### PR TITLE
micropython: assert the DEBUG is not defined

### DIFF
--- a/micropython/port.def.sh
+++ b/micropython/port.def.sh
@@ -43,6 +43,13 @@ p_prepare() {
 }
 
 p_build() {
+	# Ensure DEBUG environmental doesn't leak into micropython's build environment,
+	# as it can cause the garbage collector and memory optimization to be turned off
+	# issue: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1588
+	if [ -n "${DEBUG+set}" ]; then
+        b_die "DEBUG is defined"
+    fi
+
 	#
 	# Micropython internal use stack/heap size (not actual application stack/heap)
 	# Values are to be overwritten in _targets/build.project.*


### PR DESCRIPTION
Catch `DEBUG` env-var leaking into micropython's build environment

JIRA: CI-665

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Adds an assertion to prevent future `DEBUG` variable leaks.

Prevents from occurring: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1588

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The DEBUG variable leaked into the micropython build environment, forcing unoptimized compilation. This increased the baseline memory overhead and reduced the maximum contiguous free heap space, causing our ia32-generic-qemu tests to fail during memory allocation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
