### PR TITLE
port.def: add mirror-specific archive filenames

### DIFF
--- a/coreMQTT/port.def.sh
+++ b/coreMQTT/port.def.sh
@@ -9,7 +9,7 @@
 	desc="Client implementation of the MQTT 3.1.1 specification for embedded devices"
 
 	source="https://github.com/FreeRTOS/coreMQTT/archive/refs/tags/"
-	archive_filename="${name}-${version}.tar.gz"
+	archive_filename=("${name}-${version}.tar.gz" "v${version}.tar.gz")
 	src_path="${name}-${version}/"
 
 	size="831617"

--- a/coremark/port.def.sh
+++ b/coremark/port.def.sh
@@ -11,7 +11,7 @@
 	commit="d5fad6bd094899101a4e5fd53af7298160ced6ab"
 
 	source="https://github.com/eembc/coremark/archive/"
-	archive_filename="${commit}.tar.gz"
+	archive_filename=("${name}-${version}.tar.gz" "${commit}.tar.gz")
 	src_path="${name}-${commit}/"
 
 	size="402348"

--- a/coremark_pro/port.def.sh
+++ b/coremark_pro/port.def.sh
@@ -11,7 +11,7 @@
 	commit="4832cc67b0926c7a80a4b7ce0ce00f4640ea6bec"
 
 	source="https://codeload.github.com/eembc/coremark-pro/tar.gz/"
-	archive_filename="coremark-pro-${commit}.tar.gz"
+	archive_filename=("coremark-pro-${version}.tar.gz" "${commit}")
 	src_path="coremark-pro-${commit}/"
 
 	size="13792200"

--- a/fs_mark/port.def.sh
+++ b/fs_mark/port.def.sh
@@ -11,7 +11,7 @@
 	commit="2628be58146de63a13260ff64550f84275556c0e"
 
 	source="https://github.com/josefbacik/fs_mark/archive/"
-	archive_filename="${commit}.tar.gz"
+	archive_filename=("${name}-${version}.tar.gz" "${commit}.tar.gz")
 	src_path="${name}-${commit}/"
 
 	size="22433"

--- a/heatshrink/port.def.sh
+++ b/heatshrink/port.def.sh
@@ -9,7 +9,7 @@
 	desc="Data compression library for embedded/real-time systems based on LZSS"
 
 	source="https://github.com/atomicobject/heatshrink/archive/refs/tags/"
-	archive_filename="${name}-${version}.tar.gz"
+	archive_filename=("${name}-${version}.tar.gz" "v${version}.tar.gz")
 	src_path="${name}-${version}/"
 
 	size="36945"

--- a/mbedtls/port.def.sh
+++ b/mbedtls/port.def.sh
@@ -9,7 +9,7 @@
 	desc="SSL/TLS and cryptography library suitable for embedded systems"
 
 	source="https://github.com/Mbed-TLS/mbedtls/archive/"
-	archive_filename="v${version}.tar.gz"
+	archive_filename=("${name}-${version}.tar.gz" "v${version}.tar.gz")
 	src_path="${name}-${version}/"
 
 	size="3711231"

--- a/openiked/port.def.sh
+++ b/openiked/port.def.sh
@@ -9,7 +9,7 @@
 	desc="IKEv2 daemon"
 
 	source="https://github.com/openiked/openiked-portable/archive/refs/tags/"
-	archive_filename="v${version}.tar.gz"
+	archive_filename=("openiked-portable-${version}.tar.gz" "v${version}.tar.gz")
 	src_path="openiked-portable-${version}/"
 
 	size="296532"

--- a/picocom/port.def.sh
+++ b/picocom/port.def.sh
@@ -9,7 +9,7 @@
 	desc="Dumb Terminal Emulator"
 
 	source="https://github.com/npat-efault/picocom/archive/refs/tags/"
-	archive_filename="${version}.tar.gz"
+	archive_filename=("${name}-${version}.tar.gz" "${version}.tar.gz")
 	src_path="${name}-${version}/"
 
 	size="121686"

--- a/smolrtsp/port.def.sh
+++ b/smolrtsp/port.def.sh
@@ -9,7 +9,7 @@
 	desc="A lightweight real-time streaming library for IP cameras"
 
 	source="https://github.com/OpenIPC/smolrtsp/archive/refs/tags/"
-	archive_filename="v${version}.tar.gz"
+	archive_filename=("${name}-${version}.tar.gz" "v${version}.tar.gz")
 	src_path="${name}-${version}/"
 
 	size="1471348"

--- a/sscep/port.def.sh
+++ b/sscep/port.def.sh
@@ -9,7 +9,7 @@
 	desc="A command line client for the SCEP protocol"
 
 	source="https://github.com/certnanny/sscep/archive/refs/tags/"
-	archive_filename="v${version}.tar.gz"
+	archive_filename=("${name}-${version}.tar.gz" "v${version}.tar.gz")
 	src_path="${name}-${version}/"
 
 	size="97647"


### PR DESCRIPTION
They got chopped out during port migration to port defs.

JIRA: RTOS-1266

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [X] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-build/pull/272
- [ ] I will merge this PR by myself when appropriate.
