### PR TITLE
Fix port.def.sh formatting in lsb_vsx and micropython

### DIFF
--- a/lsb_vsx/vsx/port-phoenix.def.sh
+++ b/lsb_vsx/vsx/port-phoenix.def.sh
@@ -85,7 +85,7 @@ p_build_test() {
 	(
 		cd "${test_sets_path}" &&
 			HOME="${test_sets_path}" VSXBIN="${PREFIX_BUILD}/host-prog" \
-			"${PREFIX_BUILD}/host-prog/tcc" -p -b -s "${PREFIX_PORT}/config/scen.bld"
+				"${PREFIX_BUILD}/host-prog/tcc" -p -b -s "${PREFIX_PORT}/config/scen.bld"
 	)
 
 	find "${test_sets_path}" -type f -executable -name "T.*" -print0 | while IFS= read -r -d '' test_path; do

--- a/micropython/port.def.sh
+++ b/micropython/port.def.sh
@@ -47,8 +47,8 @@ p_build() {
 	# as it can cause the garbage collector and memory optimization to be turned off
 	# issue: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1588
 	if [ -n "${DEBUG+set}" ]; then
-        b_die "DEBUG is defined"
-    fi
+		b_die "DEBUG is defined"
+	fi
 
 	#
 	# Micropython internal use stack/heap size (not actual application stack/heap)
@@ -69,7 +69,7 @@ p_build() {
 
 	# TODO: use strip manually
 	case "${TARGET_FAMILY}" in
-	armv7m7|armv7r5f)
+	armv7m7 | armv7r5f)
 		STRIPEXP="--strip-unneeded"
 		;;
 	ia32)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Some ill-formatted changes sneaked in between port.def.sh migration and inclusion of shfmt to the CI.

JIRA: CI-667

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
