### PR TITLE
coremark_pro: fix build by disabling parallel make

### DIFF
--- a/coremark_pro/port.def.sh
+++ b/coremark_pro/port.def.sh
@@ -33,6 +33,9 @@ p_prepare() {
 }
 
 p_build() {
+	# Disable parallel building as it may cause failures: https://github.com/eembc/coremark-pro/issues/9
+	local -x MAKEFLAGS="${MAKEFLAGS}${MAKEFLAGS:+ }-j1"
+
 	make -C "${PREFIX_PORT_WORKDIR}" TARGET="${HOST}" build
 
 	# Remove empty data directory (not needed)


### PR DESCRIPTION
Parallel build causes build failures due to a known issue. See: https://github.com/eembc/coremark-pro/issues/9

YT: CI-673

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
